### PR TITLE
Made ObjectTranslatorPool thread-safe

### DIFF
--- a/Core/NLua/NLua.Net35.csproj
+++ b/Core/NLua/NLua.Net35.csproj
@@ -18,7 +18,7 @@
     <DebugType>full</DebugType>
     <Optimize>False</Optimize>
     <OutputPath>..\..\Run\Debug\net35\</OutputPath>
-    <DefineConstants>DEBUG</DefineConstants>
+    <DefineConstants>DEBUG;NET_3_5</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
@@ -27,7 +27,7 @@
     <DebugType>none</DebugType>
     <Optimize>True</Optimize>
     <OutputPath>..\..\Run\Release\net35\</OutputPath>
-    <DefineConstants>RELEASE</DefineConstants>
+    <DefineConstants>RELEASE;NET_3_5</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <PlatformTarget>AnyCPU</PlatformTarget>
@@ -35,7 +35,7 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'DebugKopiLua|AnyCPU'">
     <DebugSymbols>true</DebugSymbols>
     <OutputPath>bin\DebugKopiLua\</OutputPath>
-    <DefineConstants>DEBUG;USE_KOPILUA</DefineConstants>
+    <DefineConstants>DEBUG;NET_3_5;USE_KOPILUA</DefineConstants>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <DebugType>full</DebugType>
     <PlatformTarget>AnyCPU</PlatformTarget>
@@ -44,7 +44,7 @@
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'ReleaseKopiLua|AnyCPU'">
     <OutputPath>bin\ReleaseKopiLua\</OutputPath>
-    <DefineConstants>USE_KOPILUA</DefineConstants>
+    <DefineConstants>NET_3_5;USE_KOPILUA</DefineConstants>
   </PropertyGroup>
   <PropertyGroup>
     <SignAssembly>true</SignAssembly>

--- a/Core/NLua/ObjectTranslatorPool.cs
+++ b/Core/NLua/ObjectTranslatorPool.cs
@@ -1,5 +1,9 @@
 using System;
+#if WINDOWS_PHONE || NET_3_5
 using System.Collections.Generic;
+#else
+using System.Collections.Concurrent;
+#endif
 
 /*
  * This file is part of NLua.
@@ -27,19 +31,23 @@ using System.Collections.Generic;
 
 namespace NLua
 {
-	#if USE_KOPILUA
+#if USE_KOPILUA
 	using LuaCore  = KopiLua.Lua;
 	using LuaState = KopiLua.LuaState;
-	#else
+#else
 	using LuaCore  = KeraLua.Lua;
 	using LuaState = KeraLua.LuaState;
-	#endif
+#endif
 
 	internal class ObjectTranslatorPool
 	{
-		private static volatile ObjectTranslatorPool instance = new ObjectTranslatorPool ();		
+		private static volatile ObjectTranslatorPool instance = new ObjectTranslatorPool ();
+#if WINDOWS_PHONE || NET_3_5
 		private Dictionary<LuaState, ObjectTranslator> translators = new Dictionary<LuaState, ObjectTranslator>();
-		
+#else
+        private ConcurrentDictionary<LuaState, ObjectTranslator> translators = new ConcurrentDictionary<LuaState, ObjectTranslator>();
+#endif
+
 		public static ObjectTranslatorPool Instance
 		{
 			get
@@ -54,28 +62,51 @@ namespace NLua
 		
 		public void Add (LuaState luaState, ObjectTranslator translator)
 		{
-			translators.Add(luaState , translator);			
+#if WINDOWS_PHONE || NET_3_5
+			lock (translators)
+				translators.Add (luaState, translator);			
+#else
+			if (!translators.TryAdd (luaState, translator))
+				throw new ArgumentException ("An item with the same key has already been added. ", "luaState");
+#endif
 		}
-		
+
 		public ObjectTranslator Find (LuaState luaState)
 		{
-			if (translators.ContainsKey (luaState))
-				return translators [luaState];
+#if WINDOWS_PHONE || NET_3_5
+			lock (translators) 
+			{
+#endif
+			ObjectTranslator translator;
 
-			LuaState main = LuaCore.LuaNetGetMainState (luaState);
+			if (!translators.TryGetValue (luaState, out translator))
+			{
+				LuaState main = LuaCore.LuaNetGetMainState (luaState);
 
-			if (translators.ContainsKey (main))
-				return translators [main];
+				if (!translators.TryGetValue (main, out translator))
+					translator = null;
+			}
 			
-			return null;
+			return translator;
+#if WINDOWS_PHONE || NET_3_5
+			}
+#endif
 		}
 		
 		public void Remove (LuaState luaState)
 		{
-			if (!translators.ContainsKey (luaState))
-				return;
+#if WINDOWS_PHONE || NET_3_5
+			lock (translators)
+			{
+				if (!translators.ContainsKey (luaState))
+					return;
 			
-			translators.Remove (luaState);
+				translators.Remove (luaState);
+			}
+#else
+			ObjectTranslator translator;
+			translators.TryRemove (luaState, out translator);
+#endif 
 		}
 	}
 }

--- a/Core/NLua/ObjectTranslatorPool.cs
+++ b/Core/NLua/ObjectTranslatorPool.cs
@@ -31,21 +31,21 @@ using System.Collections.Concurrent;
 
 namespace NLua
 {
-#if USE_KOPILUA
+	#if USE_KOPILUA
 	using LuaCore  = KopiLua.Lua;
 	using LuaState = KopiLua.LuaState;
-#else
+	#else
 	using LuaCore  = KeraLua.Lua;
 	using LuaState = KeraLua.LuaState;
-#endif
+	#endif
 
 	internal class ObjectTranslatorPool
 	{
-		private static volatile ObjectTranslatorPool instance = new ObjectTranslatorPool ();
+		private static volatile ObjectTranslatorPool instance = new ObjectTranslatorPool ();		
 #if WINDOWS_PHONE || NET_3_5
 		private Dictionary<LuaState, ObjectTranslator> translators = new Dictionary<LuaState, ObjectTranslator>();
 #else
-        private ConcurrentDictionary<LuaState, ObjectTranslator> translators = new ConcurrentDictionary<LuaState, ObjectTranslator>();
+		private ConcurrentDictionary<LuaState, ObjectTranslator> translators = new ConcurrentDictionary<LuaState, ObjectTranslator>();
 #endif
 
 		public static ObjectTranslatorPool Instance


### PR DESCRIPTION
This is a change that would make ObjectTranslatorPool thread-safe. I made sure that it will work even when ConcurrentDictionary is not present (NET35, WP7) - in those cases we use lock explicitly. I believe this can be forwarded (as is) as a Pull Request to NLua directly. 